### PR TITLE
Refactors automated release process

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,4 +1,4 @@
-name: Dev Release
+name: Deploy Development
 
 on:
   workflow_dispatch:
@@ -7,9 +7,6 @@ on:
         description: "Run without making changes"
         type: boolean
         default: false
-  push:
-    branches:
-      - dev
 
 permissions:
   contents: write

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,62 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 1.2.0)"
+        required: true
+        type: string
+      target_branch:
+        description: "Branch to open the PR against (e.g. main, v1.2.3)"
+        required: false
+        default: "main"
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.target_branch }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Generate changelog
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --tag v${{ inputs.version }} --output CHANGELOG.md
+
+      - name: Update sdk-release.json
+        run: |
+          UPDATED=$(jq --arg version "${{ inputs.version }}" \
+                       --arg date "$(date -u +%Y-%m-%d)" \
+                       '.version = $version | .releaseDate = $date' \
+                       sdk-release.json)
+          echo "$UPDATED" > sdk-release.json
+          echo "$UPDATED" > Sources/Resources/sdk-release.json
+
+      - name: Create release branch and PR
+        run: |
+          BRANCH="chore/release-v${{ inputs.version }}"
+          git checkout -b "$BRANCH"
+          git add CHANGELOG.md sdk-release.json Sources/Resources/sdk-release.json
+          git commit -m "chore: changelog update for v${{ inputs.version }}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore(release): v${{ inputs.version }}" \
+            --body "Updates the changelog and release metadata for **v${{ inputs.version }}**. After merging, you can trigger the release manually via the Deploy workflow." \
+            --base "${{ inputs.target_branch }}" \
+            --head "$BRANCH"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Deploy Production
 
 on:
   workflow_dispatch:
@@ -7,10 +7,6 @@ on:
         description: "Run without making changes"
         type: boolean
         default: false
-  push:
-    branches:
-      - main
-      - master
 
 permissions:
   contents: write

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,4 +1,4 @@
-name: Snapshot Release
+name: Deploy Snapshot
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -70,15 +70,46 @@ git-cliff --tag v1.1.0 --output CHANGELOG.md
 ```
 
 ## Releasing a new version
-To release a new version, follow the [git convention](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines.
 
-Releases are fully automated via CI, so pls do not create tags manually :)
+Follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines when writing commit messages — this is what `git-cliff` uses to group entries in the changelog.
 
-| Release type | Trigger | Tag format |
-|---|---|---|
-| Production | Merge PR to `main` | `vX.Y.Z` |
-| Development | Merge PR to `dev` | `vX.Y.Z-dev.N` |
-| Snapshot | Manual dispatch in GitHub Actions | snapshot tag |
+### Branch strategy
+
+- **Feature work**: feature branch → PR to `main` (or a version branch like `v1.2.3` when working on multiple versions in parallel)
+- **No permanent `dev` branch** — all releases are triggered manually via GitHub Actions
+
+### Workflows
+
+| Workflow | Trigger | Allowed branches | Tag format |
+|---|---|---|---|
+| **Prepare Release** | Manual | any | — |
+| **Deploy Snapshot** | Manual | any | `vX.Y.Z-snapshot.<hash>` |
+| **Deploy Development** | Manual | `main`, `v*.*.*` | `vX.Y.Z-dev.N` |
+| **Deploy Production** | Manual | `main` only | `vX.Y.Z` |
+
+### Prepare Release
+
+1. Go to **Actions → Prepare Release → Run workflow**, enter the version (e.g. `1.2.0`) and the `target_branch` (default: `main`). This will be the branch the PR is targeted at w/ the updated version & release dates
+2. The workflow updates `CHANGELOG.md` and `sdk-release.json` (version + today's date), then opens a PR against the target branch.
+3. Review and merge the PR.
+
+> If the PR sits for more than a day before deploying, retrigger Prepare Release to refresh the date — the Deploy workflows validate that `sdk-release.json` contains today's date.
+
+### Production deploy
+
+After merging the Prepare Release PR, go to **Actions → Deploy Production → Run workflow** from `main`.
+
+> The git tag (e.g. `v1.2.0`) and GitHub release are created automatically — do not create tags manually.
+
+### Development deploy
+
+After merging the Prepare Release PR, go to **Actions → Deploy Development → Run workflow** from `main` or a version branch (e.g. `v1.2.3`).
+
+> The git tag (e.g. `v1.2.0`) and GitHub release are created automatically — do not create tags manually.
+
+### Snapshot deploy
+
+Go to **Actions → Deploy Snapshot → Run workflow** from any branch. No Prepare Release step needed — snapshots skip the date validation.
 
 ## Logged Data Structure
 When a `log` flag is enabled on a `CameraSettingsInput` and its corresponding mode is set to `auto`, the measurement result will include a `camera_settings` object containing the relevant log.


### PR DESCRIPTION
Overhauls the project's release strategy, moving to a controlled, manual two-step process for preparing and deploying releases. This change enhances clarity and control over the release lifecycle.

### Key Changes:
*   **Introduces a `Prepare Release` workflow**: This new workflow automates the generation of `CHANGELOG.md`, updates the version and release date in `sdk-release.json`, and creates a pull request for review.
*   **Converts deployment workflows to manual triggers**: All existing deployment workflows (`Deploy Development`, `Deploy Production`, `Deploy Snapshot`) now utilize `workflow_dispatch` triggers. This removes push-based automatic deployments, providing more explicit control over when releases occur.
*   **Renames workflows for clarity**: Existing workflows are renamed (e.g., `Dev Release` to `Deploy Development`) to better reflect their purpose within the new release flow.
*   **Updates documentation**: The `README.md` is comprehensively updated to detail the new branch strategy and provide step-by-step instructions for performing releases using the revised workflows.